### PR TITLE
fix(vm): add check for empty groupings

### DIFF
--- a/src/app/template/containers/template-filter-selector.container.ts
+++ b/src/app/template/containers/template-filter-selector.container.ts
@@ -46,19 +46,7 @@ export class TemplateFilterListSelectorContainerComponent implements AfterViewIn
 
   @Output() public selectedTemplateChange = new EventEmitter<BaseTemplateModel>();
 
-  public groupings = [
-    {
-      key: 'zones',
-      label: 'GROUP_BY_ZONES',
-      selector: (item: BaseTemplateModel) => item.zoneId || '',
-      name: (item: BaseTemplateModel) => item.zoneName || 'NO_ZONE'
-    }
-  ];
-
-  constructor(
-    private store: Store<State>,
-    private cd: ChangeDetectorRef
-  ) {
+  constructor(private store: Store<State>, private cd: ChangeDetectorRef) {
   }
 
   public ngAfterViewInit() {

--- a/src/app/template/template-filters/template-filters.component.ts
+++ b/src/app/template/template-filters/template-filters.component.ts
@@ -77,7 +77,9 @@ export class TemplateFiltersComponent implements OnInit {
       }
     }
 
-    this.availableGroupings = reorderAvailableGroupings(this.availableGroupings, this.selectedGroupings);
+    if (this.availableGroupings && this.selectedGroupings) {
+      this.availableGroupings = reorderAvailableGroupings(this.availableGroupings, this.selectedGroupings);
+    }
   }
 
   public get locale(): Language {


### PR DESCRIPTION
Fixes #1063 
The problem was that creating a virtual machine uses a component from the different area - template-filter.component. This component provides a lot of inputs and not all of them was used.
I think this is not the best decision to use it like that but it works and I just checked some inputs on a null value.