### PR TITLE
build: set the node version explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: node_js
 node_js:
-  - 'stable'
+  - '8'
 
 services:
   - docker


### PR DESCRIPTION
NodeJs released new stable version and some of our dependencies don't work with that version. So I set node version explicitly.