### PR TITLE
fix: get rid of cidr library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@ngx-translate/core": "^8.0.0",
     "@ngx-translate/http-loader": "^2.0.0",
     "chart.js": "2.7.0",
-    "cidr-regex": "^2.0.8",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "lodash": "^4.17.4",

--- a/src/app/security-group/components/sg-rule-addition-form/sg-rule-addition-form.component.ts
+++ b/src/app/security-group/components/sg-rule-addition-form/sg-rule-addition-form.component.ts
@@ -9,7 +9,6 @@ import {
   Validators
 } from '@angular/forms';
 import { Subscription } from 'rxjs/Subscription';
-import 'rxjs/add/operator/startWith';
 import { TranslateService } from '@ngx-translate/core';
 import { ErrorStateMatcher } from '@angular/material';
 

--- a/src/app/security-group/components/sg-rule-addition-form/sg-rule-addition-form.component.ts
+++ b/src/app/security-group/components/sg-rule-addition-form/sg-rule-addition-form.component.ts
@@ -9,12 +9,12 @@ import {
   Validators
 } from '@angular/forms';
 import { Subscription } from 'rxjs/Subscription';
+import 'rxjs/add/operator/startWith';
 import { TranslateService } from '@ngx-translate/core';
 import { ErrorStateMatcher } from '@angular/material';
 
 import { IPVersion, NetworkRuleType } from '../../sg.model';
 import { NetworkProtocol } from '../../network-rule.model';
-import { Utils } from '../../../shared/services/utils/utils.service';
 import {
   cidrValidator,
   endPortValidator,
@@ -31,8 +31,8 @@ import {
   icmpV4Types,
   icmpV6Types
 } from '../../../shared/icmp/icmp-types';
-import 'rxjs/add/operator/startWith';
 import { FirewallRule } from '../../shared/models';
+import { CidrUtils } from '../../../shared/utils/cidr-utils';
 
 
 export class PortsErrorStateMatcher implements ErrorStateMatcher {
@@ -250,7 +250,7 @@ export class SGRuleAdditionFormComponent implements OnDestroy {
 
   private onCidrChange() {
     this.cidrChanges = this.cidr.valueChanges
-      .map(Utils.cidrType)
+      .map(CidrUtils.getCidrIpVersion)
       .distinctUntilChanged()
       .filter(() => this.isIcmpProtocol === true)
       .subscribe(() => {  // invokes only when cidr change IP version and protocol equals ICMP
@@ -367,7 +367,7 @@ export class SGRuleAdditionFormComponent implements OnDestroy {
   }
 
   private getIcmpTypes(): IcmpType[] {
-    const cidrIpVersion = Utils.cidrType(this.cidr.value);
+    const cidrIpVersion = CidrUtils.getCidrIpVersion(this.cidr.value);
     if (!cidrIpVersion) {
       return [];
     }
@@ -388,7 +388,7 @@ export class SGRuleAdditionFormComponent implements OnDestroy {
   }
 
   private getIcmpTypeTranslationToken(type: number) {
-    const cidrIpVersion = Utils.cidrType(this.cidr.value);
+    const cidrIpVersion = CidrUtils.getCidrIpVersion(this.cidr.value);
     if (!cidrIpVersion) {
       return;
     }
@@ -398,7 +398,7 @@ export class SGRuleAdditionFormComponent implements OnDestroy {
   }
 
   private getIcmpCodeTranslationToken(type: number, code: number) {
-    const cidrIpVersion = Utils.cidrType(this.cidr.value);
+    const cidrIpVersion = CidrUtils.getCidrIpVersion(this.cidr.value);
     if (!cidrIpVersion) {
       return;
     }

--- a/src/app/security-group/sg-rules/sg-rule.component.ts
+++ b/src/app/security-group/sg-rules/sg-rule.component.ts
@@ -1,19 +1,15 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output
-} from '@angular/core';
-import { Utils } from '../../shared/services/utils/utils.service';
-import { NetworkProtocol, NetworkRule } from '../network-rule.model';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+
 import {
   GetICMPCodeTranslationToken,
-  GetICMPTypeTranslationToken, GetICMPV6CodeTranslationToken,
+  GetICMPTypeTranslationToken,
+  GetICMPV6CodeTranslationToken,
   GetICMPV6TypeTranslationToken
 } from '../../shared/icmp/icmp-types';
 import { IPVersion, NetworkRuleType } from '../sg.model';
+import { NetworkProtocol, NetworkRule } from '../network-rule.model';
+import { CidrUtils } from '../../shared/utils/cidr-utils';
 
 @Component({
   selector: 'cs-security-group-rule',
@@ -50,19 +46,19 @@ export class SgRuleComponent {
   }
 
   public get icmpTypeTranslationToken(): string {
-    return Utils.cidrType(this.item.CIDR) === IPVersion.ipv4
+    return CidrUtils.getCidrIpVersion(this.item.CIDR) === IPVersion.ipv4
       ? GetICMPTypeTranslationToken(this.item.icmpType)
       : GetICMPV6TypeTranslationToken(this.item.icmpType);
   }
 
   public get icmpCodeTranslationToken(): string {
-    return Utils.cidrType(this.item.CIDR) === IPVersion.ipv4
+    return CidrUtils.getCidrIpVersion(this.item.CIDR) === IPVersion.ipv4
       ? GetICMPCodeTranslationToken(this.item.icmpType, this.item.icmpCode)
       : GetICMPV6CodeTranslationToken(this.item.icmpType, this.item.icmpCode);
   }
 
   public get ruleParams(): Object {
-    const ipVersion = Utils.cidrType(this.item.CIDR) === IPVersion.ipv4
+    const ipVersion = CidrUtils.getCidrIpVersion(this.item.CIDR) === IPVersion.ipv4
       ? IPVersion.ipv4
       : IPVersion.ipv6;
 

--- a/src/app/security-group/sg-rules/sg-rules.component.ts
+++ b/src/app/security-group/sg-rules/sg-rules.component.ts
@@ -3,7 +3,6 @@ import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 
 import { NotificationService } from '../../shared/services/notification.service';
-import { Utils } from '../../shared/services/utils/utils.service';
 import { NetworkRuleService } from '../services/network-rule.service';
 import { getType, IPVersion, NetworkRuleType, SecurityGroup, SecurityGroupType } from '../sg.model';
 import { NetworkProtocol, NetworkRule } from '../network-rule.model';
@@ -11,6 +10,7 @@ import { DialogService } from '../../dialog/dialog-service/dialog.service';
 import { SgRuleComponent } from './sg-rule.component';
 import { FirewallRule } from '../shared/models';
 import { SecurityGroupViewMode } from '../sg-view-mode';
+import { CidrUtils } from '../../shared/utils/cidr-utils';
 
 
 @Component({
@@ -221,7 +221,7 @@ export class SgRulesComponent implements OnInit, OnChanges {
   private filterRules(rules: NetworkRule[]) {
     return rules.filter((rule: NetworkRule) => {
       const filterByIPversion = (item: NetworkRule) => {
-        const ruleIPversion = item.CIDR && Utils.cidrType(item.CIDR) === IPVersion.ipv6
+        const ruleIPversion = item.CIDR && CidrUtils.getCidrIpVersion(item.CIDR) === IPVersion.ipv6
           ? IPVersion.ipv6
           : IPVersion.ipv4;
         return !this.selectedIPVersion.length

--- a/src/app/security-group/shared/validators/cidr.validator.ts
+++ b/src/app/security-group/shared/validators/cidr.validator.ts
@@ -1,9 +1,9 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
-import { Utils } from '../../../shared/services/utils/utils.service';
+import { CidrUtils } from '../../../shared/utils/cidr-utils';
 
 export function cidrValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
-    const isValid = Utils.cidrIsValid(control.value);
+    const isValid = CidrUtils.isCidrValid(control.value);
     return isValid ? null : { 'cidrValidator': { value: control.value } };
   }
 }

--- a/src/app/security-group/shared/validators/icmp-code.validator.ts
+++ b/src/app/security-group/shared/validators/icmp-code.validator.ts
@@ -1,14 +1,14 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 
 import { icmpV4Types, icmpV6Types } from '../../../shared/icmp/icmp-types';
-import { Utils } from '../../../shared/services/utils/utils.service';
 import { IPVersion } from '../../sg.model';
+import { CidrUtils } from '../../../shared/utils/cidr-utils';
 
 export function icmpCodeValidator(cidr: AbstractControl, icmpType: AbstractControl) {
   return (control: AbstractControl): ValidationErrors | null => {
     const code = +control.value;
     const type = +icmpType.value;
-    const types = Utils.cidrType(cidr.value) === IPVersion.ipv4 ? icmpV4Types : icmpV6Types;
+    const types = CidrUtils.getCidrIpVersion(cidr.value) === IPVersion.ipv4 ? icmpV4Types : icmpV6Types;
     const typeObject = types.find(value => value.type === type);
     if (!typeObject) {
       return null;

--- a/src/app/security-group/shared/validators/icmp-type.validator.ts
+++ b/src/app/security-group/shared/validators/icmp-type.validator.ts
@@ -1,14 +1,14 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 import { icmpV4Types, icmpV6Types } from '../../../shared/icmp/icmp-types';
-import { Utils } from '../../../shared/services/utils/utils.service';
 import { IPVersion } from '../../sg.model';
+import { CidrUtils } from '../../../shared/utils/cidr-utils';
 
 
 export function icmpTypeValidator(cidr: AbstractControl): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const type = +control.value;
-    const types = Utils.cidrType(cidr.value) === IPVersion.ipv4 ? icmpV4Types : icmpV6Types;
+    const types = CidrUtils.getCidrIpVersion(cidr.value) === IPVersion.ipv4 ? icmpV4Types : icmpV6Types;
     const index = types.findIndex(value => value.type === type);
     return index > -1 ? null : { 'icmpTypeValidator': { value: control.value } };
   }

--- a/src/app/shared/components/security-group-builder/rule/security-group-builder-rule.component.ts
+++ b/src/app/shared/components/security-group-builder/rule/security-group-builder-rule.component.ts
@@ -1,12 +1,9 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { NetworkProtocol } from '../../../../security-group/network-rule.model';
-import {
-  GetICMPCodeTranslationToken,
-  GetICMPTypeTranslationToken
-} from '../../../icmp/icmp-types';
-import { Utils } from '../../../services/utils/utils.service';
+import { GetICMPCodeTranslationToken, GetICMPTypeTranslationToken } from '../../../icmp/icmp-types';
 import { RuleListItem } from '../security-group-builder.component';
+import { CidrUtils } from '../../../utils/cidr-utils';
 
 
 @Component({
@@ -85,7 +82,7 @@ export class SecurityGroupBuilderRuleComponent {
       type: this.translateService.instant(this.typeTranslationToken),
       protocol: this.translateService.instant(this.protocolTranslationToken),
       cidr: this.item.rule.CIDR,
-      ipVersion: Utils.cidrType(this.item.rule.CIDR)
+      ipVersion: CidrUtils.getCidrIpVersion(this.item.rule.CIDR)
     };
 
     let ruleParams;

--- a/src/app/shared/services/utils/utils.service.spec.ts
+++ b/src/app/shared/services/utils/utils.service.spec.ts
@@ -1,6 +1,5 @@
 import { RouterState } from '@angular/router';
 import { Utils } from './utils.service';
-import { IPVersion } from '../../../security-group/sg.model';
 
 
 const divideFixture = [
@@ -68,37 +67,6 @@ const getRouteWithoutQueryParamsFixture = [
   }
 ];
 
-const validCidrV4Values = [
-  '99.198.122.146/32',
-  '46.51.197.88/8',
-  '173.194.34.134/12',
-  '0.0.0.0/0'
-];
-const validCidrV6Values = [
-  'fe80:0000:0000:0000:0204:61ff:fe9d:f156/100',
-  '::1/128',
-  'a:b:c:d:e:f:0::/64',
-  'FE80::/10'
-];
-const invalidCidrValues = [
-  'invalid',
-  '',
-  ' ',
-  null,
-  // IP v4
-  '.100.100.100.100/16',
-  '100.100.100.100./32',
-  'http://123.123.123/28',
-  '1000.2.3.4/14',
-  // IP v6
-  'fe80:0000:0000:0000:0204:61ff:fe9d:f156/129',
-  '1::5:400.2.3.4/64',
-  '2001:0000:1234:0000:0000:C1C0:ABCD:0876  0/64',
-  '1.2.3.4::/64',
-  ':::/64',
-  '::2222:3333:4444:5555:7777:8888::/64'
-];
-
 describe('Utils service', () => {
   it('should generate unique id', () => {
     expect(Utils.getUniqueId()).toBeDefined();
@@ -163,26 +131,4 @@ describe('Utils service', () => {
     color = '#000000';
     expect(Utils.isColorDark(color)).toBeTruthy();
   });
-
-  it('should check if CIDR valid', () => {
-    const validCidrValues = [...validCidrV4Values, ...validCidrV6Values];
-    for (const value of validCidrValues) {
-      expect(Utils.cidrIsValid(value)).toBe(true);
-    }
-    for (const value of invalidCidrValues) {
-      expect(Utils.cidrIsValid(value)).toBe(false);
-    }
-  });
-
-  it('should return proper CIDR type', () => {
-    for (const value of validCidrV4Values) {
-      expect(Utils.cidrType(value)).toBe(IPVersion.ipv4);
-    }
-    for (const value of validCidrV6Values) {
-      expect(Utils.cidrType(value)).toBe(IPVersion.ipv6);
-    }
-    for (const value of invalidCidrValues) {
-      expect(Utils.cidrType(value)).toBe(null);
-    }
-  })
 });

--- a/src/app/shared/services/utils/utils.service.ts
+++ b/src/app/shared/services/utils/utils.service.ts
@@ -1,8 +1,6 @@
 import { Params, RouterState, RouterStateSnapshot } from '@angular/router';
 import { RouterStateSerializer } from '@ngrx/router-store';
-import { IPVersion } from '../../../security-group/sg.model';
 import * as uuid from 'uuid';
-import * as cidrRegex from 'cidr-regex';
 
 export class Utils {
   public static getUniqueId(): string {
@@ -87,18 +85,6 @@ export class Utils {
   public static sortByName = (a, b) => {
     return a.name && a.name.localeCompare(b.name);
   };
-
-  public static cidrIsValid(cidr: string | null): boolean {
-    return cidrRegex({exact: true}).test(cidr);
-  }
-
-  public static cidrType(cidr: string | null): IPVersion | null {
-    if (!Utils.cidrIsValid(cidr)) {
-      return null;
-    }
-    const isIPv4 = cidrRegex.v4({exact: true}).test(cidr);
-    return isIPv4 ? IPVersion.ipv4 : IPVersion.ipv6;
-  }
 }
 
 

--- a/src/app/shared/utils/cidr-utils.spec.ts
+++ b/src/app/shared/utils/cidr-utils.spec.ts
@@ -1,0 +1,77 @@
+import { CidrUtils } from './cidr-utils';
+import { IPVersion } from '../../security-group/sg.model';
+
+const validCidrV4Values = [
+  '99.198.122.146/32',
+  '46.51.197.88/8',
+  '173.194.34.134/12',
+  '0.0.0.0/0'
+];
+const validCidrV6Values = [
+  'fe80:0000:0000:0000:0204:61ff:fe9d:f156/100',
+  '::1/128',
+  'a:b:c:d:e:f:0::/64',
+  'FE80::/10'
+];
+const invalidCidrValues = [
+  'invalid',
+  '',
+  ' ',
+  null,
+  // IP v4
+  '.100.100.100.100/16',
+  '100.100.100.100./32',
+  'http://123.123.123/28',
+  '1000.2.3.4/14',
+  '0.0.0.0',
+  // IP v6
+  'fe80:0000:0000:0000:0204:61ff:fe9d:f156/129',
+  '1::5:400.2.3.4/64',
+  '2001:0000:1234:0000:0000:C1C0:ABCD:0876  0/64',
+  '1.2.3.4::/64',
+  '::',
+  ':::/64',
+  '::2222:3333:4444:5555:7777:8888::/64'
+];
+
+describe('CIDR Utils', () => {
+  it('should check if CIDR v4 valid', () => {
+    for (const value of validCidrV4Values) {
+      expect(CidrUtils.isCidrV4Valid(value)).toBe(true);
+    }
+    for (const value of invalidCidrValues) {
+      expect(CidrUtils.isCidrV4Valid(value)).toBe(false);
+    }
+  });
+
+  it('should check if CIDR v6 valid', () => {
+    for (const value of validCidrV6Values) {
+      expect(CidrUtils.isCidrV6Valid(value)).toBe(true);
+    }
+    for (const value of invalidCidrValues) {
+      expect(CidrUtils.isCidrV6Valid(value)).toBe(false);
+    }
+  });
+
+  it('should check if CIDR (v4 or v6) valid', () => {
+    const validCidrValues = [...validCidrV4Values, ...validCidrV6Values];
+    for (const value of validCidrValues) {
+      expect(CidrUtils.isCidrValid(value)).toBe(true);
+    }
+    for (const value of invalidCidrValues) {
+      expect(CidrUtils.isCidrValid(value)).toBe(false);
+    }
+  });
+
+  it('should return proper CIDR IP version', () => {
+    for (const value of validCidrV4Values) {
+      expect(CidrUtils.getCidrIpVersion(value)).toBe(IPVersion.ipv4);
+    }
+    for (const value of validCidrV6Values) {
+      expect(CidrUtils.getCidrIpVersion(value)).toBe(IPVersion.ipv6);
+    }
+    for (const value of invalidCidrValues) {
+      expect(CidrUtils.getCidrIpVersion(value)).toBe(null);
+    }
+  });
+});

--- a/src/app/shared/utils/cidr-utils.ts
+++ b/src/app/shared/utils/cidr-utils.ts
@@ -1,0 +1,50 @@
+import { IPVersion } from '../../security-group/sg.model';
+
+export class CidrUtils {
+  private static readonly ipV4 =
+    '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}';
+  private static readonly cidrV4 = CidrUtils.ipV4 + '\\/(3[0-2]|[12]?[0-9])';
+  private static readonly cidrV4Regex = new RegExp(`^${CidrUtils.cidrV4}$`);
+
+  private static readonly ipV6Seg = '[a-fA-F\\d]{1,4}';
+  private static readonly ipV6 =
+    '(' +
+    `(?:${CidrUtils.ipV6Seg}:){7}(?:${CidrUtils.ipV6Seg}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){6}(?:${CidrUtils.ipV4}|:${CidrUtils.ipV6Seg}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){5}(?::${CidrUtils.ipV4}|(:${CidrUtils.ipV6Seg}){1,2}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){4}(?:(:${CidrUtils.ipV6Seg}){0,1}:${CidrUtils.ipV4}|(:${CidrUtils.ipV6Seg}){1,3}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){3}(?:(:${CidrUtils.ipV6Seg}){0,2}:${CidrUtils.ipV4}|(:${CidrUtils.ipV6Seg}){1,4}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){2}(?:(:${CidrUtils.ipV6Seg}){0,3}:${CidrUtils.ipV4}|(:${CidrUtils.ipV6Seg}){1,5}|:)|` +
+    `(?:${CidrUtils.ipV6Seg}:){1}(?:(:${CidrUtils.ipV6Seg}){0,4}:${CidrUtils.ipV4}|(:${CidrUtils.ipV6Seg}){1,6}|:)|` +
+    `(?::((?::${CidrUtils.ipV6Seg}){0,5}:${CidrUtils.ipV4}|(?::${CidrUtils.ipV6Seg}){1,7}|:))` +
+    ')(%[0-9a-zA-Z]{1,})?';
+  private static readonly cidrV6 = CidrUtils.ipV6 + '\\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])';
+  private static readonly cidrV6Regex = new RegExp(`^${CidrUtils.cidrV6}$`);
+
+
+  public static isCidrV4Valid(cidr: string): boolean {
+    return CidrUtils.cidrV4Regex.test(cidr);
+  }
+
+  public static isCidrV6Valid(cidr: string): boolean {
+    return CidrUtils.cidrV6Regex.test(cidr);
+  }
+
+  public static isCidrValid(cidr: string): boolean {
+    const isIPv4 = CidrUtils.isCidrV4Valid(cidr);
+    const isIPv6 = CidrUtils.isCidrV6Valid(cidr);
+    return isIPv4 || isIPv6;
+  }
+
+  public static getCidrIpVersion(cidr: string): IPVersion | null {
+    const isIPv4 = CidrUtils.isCidrV4Valid(cidr);
+    const isIPv6 = CidrUtils.isCidrV6Valid(cidr);
+
+    if (isIPv4) {
+      return IPVersion.ipv4;
+    } else if (isIPv6) {
+      return IPVersion.ipv6;
+    }
+    return null;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,9 +1135,9 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
-cidr-regex@^2.0.8:
+cidr-regex@tamazlykar/cidr-regex:
   version "2.0.8"
-  resolved "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-2.0.8.tgz#c79bae6223d241c0860d93bfde1fb1c1c4fdcab6"
+  resolved "https://codeload.github.com/tamazlykar/cidr-regex/tar.gz/9e51a4a6144b4d7577c3e011829a7eeb61b7840f"
   dependencies:
     ip-regex "^2.1.0"
 


### PR DESCRIPTION
Fixes #997 
The library that was used broke IE, so we got rid of it.
Now CIDR validation doesn't depend on third-party libraries.