### PR TITLE
fix(sg): do not use cache for security groups

### DIFF
--- a/src/app/reducers/security-groups/redux/sg.actions.ts
+++ b/src/app/reducers/security-groups/redux/sg.actions.ts
@@ -21,9 +21,6 @@ export const CONVERT_SECURITY_GROUP = '[SecurityGroups] CONVERT_SECURITY_GROUP';
 
 export class LoadSecurityGroupRequest implements Action {
   readonly type = LOAD_SECURITY_GROUP_REQUEST;
-
-  constructor(public payload?: any) {
-  }
 }
 
 export class LoadSecurityGroupResponse implements Action {
@@ -116,6 +113,7 @@ export class ConvertSecurityGroup implements Action {
   constructor(public payload: SecurityGroup) {
   }
 }
+
 export class UpdateSecurityGroupError implements Action {
   type = UPDATE_SECURITY_GROUP_ERROR;
 

--- a/src/app/reducers/security-groups/redux/sg.actions.ts
+++ b/src/app/reducers/security-groups/redux/sg.actions.ts
@@ -21,6 +21,9 @@ export const CONVERT_SECURITY_GROUP = '[SecurityGroups] CONVERT_SECURITY_GROUP';
 
 export class LoadSecurityGroupRequest implements Action {
   readonly type = LOAD_SECURITY_GROUP_REQUEST;
+
+  constructor(public payload?: any) {
+  }
 }
 
 export class LoadSecurityGroupResponse implements Action {

--- a/src/app/security-group/services/security-group.service.ts
+++ b/src/app/security-group/services/security-group.service.ts
@@ -1,15 +1,16 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+
 import { Rules } from '../../shared/components/security-group-builder/rules';
 import { BackendResource } from '../../shared/decorators';
-import { BaseBackendCachedService } from '../../shared/services/base-backend-cached.service';
 import { ConfigService } from '../../shared/services/config.service';
 import { SecurityGroupTagService } from '../../shared/services/tags/security-group-tag.service';
 import { getType, SecurityGroup, SecurityGroupType } from '../sg.model';
 import { PrivateSecurityGroupCreationService } from './creation-services/private-security-group-creation.service';
 import { SharedSecurityGroupCreationService } from './creation-services/shared-security-group-creation.service';
 import { TemplateSecurityGroupCreationService } from './creation-services/template-security-group-creation.service';
-import { HttpClient } from '@angular/common/http';
+import { BaseBackendService } from '../../shared/services/base-backend.service';
 
 
 export const GROUP_POSTFIX = '-cs-sg';
@@ -18,7 +19,7 @@ export const GROUP_POSTFIX = '-cs-sg';
 @BackendResource({
   entity: 'SecurityGroup'
 })
-export class SecurityGroupService extends BaseBackendCachedService<SecurityGroup> {
+export class SecurityGroupService extends BaseBackendService<SecurityGroup> {
   constructor(
     protected http: HttpClient,
     private configService: ConfigService,
@@ -46,22 +47,18 @@ export class SecurityGroupService extends BaseBackendCachedService<SecurityGroup
   }
 
   public createShared(data: any, rules?: Rules): Observable<SecurityGroup> {
-    this.invalidateCache();
     return this.sharedSecurityGroupCreation.createGroup(data, rules);
   }
 
   public createTemplate(data: any, rules?: Rules): Observable<SecurityGroup> {
-    this.invalidateCache();
     return this.templateSecurityGroupCreation.createGroup(data, rules);
   }
 
   public createPrivate(data: any, rules?: Rules): Observable<SecurityGroup> {
-    this.invalidateCache();
     return this.privateSecurityGroupCreation.createGroup(data, rules);
   }
 
   public deleteGroup(securityGroup: SecurityGroup): Observable<any> {
-    this.invalidateCache();
     return this.remove({ id: securityGroup.id })
       .map(result => {
         if (!result || result.success !== 'true') {

--- a/src/app/security-group/sg-actions/sg-action.service.ts
+++ b/src/app/security-group/sg-actions/sg-action.service.ts
@@ -1,5 +1,5 @@
 import { getType, SecurityGroup, SecurityGroupType } from '../sg.model';
-import { Action } from '../../shared/models/action.model';
+import { Action } from '../../shared/models';
 
 export enum SecurityGroupActionType {
   View = 'view',

--- a/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.html
+++ b/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngFor="let action of securityGroupActionService.actions">
   <button
     mat-menu-item
-    *ngIf="action.canActivate(securityGroup)"
+    [disabled]="!action.canActivate(securityGroup)"
     (click)="onAction(action)"
   >
     <mat-icon [ngClass]="action.icon"></mat-icon>

--- a/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.html
+++ b/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngFor="let action of securityGroupActionService.actions">
+<ng-container *ngFor="let action of actions">
   <button
     mat-menu-item
     [disabled]="!action.canActivate(securityGroup)"

--- a/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.ts
+++ b/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.ts
@@ -25,13 +25,13 @@ export class SecurityGroupActionsComponent implements OnInit {
 
 
   public ngOnInit() {
+    this.actions = this.securityGroupActionService.actions;
+
     if (this.securityGroup && this.securityGroup.preselected) {
-      this.actions = this.securityGroupActionService.actions
-        .filter(action => action.command !== SecurityGroupActionType.Delete);
-    } else {
-      this.actions = this.securityGroupActionService.actions;
+      this.actions = this.actions.filter(action => action.command !== SecurityGroupActionType.Delete);
     }
   }
+
 
   public onAction(action): void {
     switch (action.command) {

--- a/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.ts
+++ b/src/app/security-group/sg-actions/sg-actions-component/sg-actions.component.ts
@@ -1,26 +1,36 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
 import { SecurityGroup } from '../../sg.model';
-import {
-  SecurityGroupActionService,
-  SecurityGroupActionType
-} from '../sg-action.service';
+import { SecurityGroupActionService, SecurityGroupActionType } from '../sg-action.service';
 import { DialogService } from '../../../dialog/dialog-service/dialog.service';
+import { Action } from '../../../shared/models';
 
 
 @Component({
   selector: 'cs-security-group-actions',
   templateUrl: 'sg-actions.component.html'
 })
-export class SecurityGroupActionsComponent {
+export class SecurityGroupActionsComponent implements OnInit {
   @Input() public securityGroup: SecurityGroup;
   @Output() public onSecurityGroupDelete = new EventEmitter<SecurityGroup>();
   @Output() public onSecurityGroupView = new EventEmitter<SecurityGroup>();
   @Output() public onSecurityGroupConvert = new EventEmitter<SecurityGroup>();
+  public actions: Action<SecurityGroup>[];
 
   constructor(
-    public securityGroupActionService: SecurityGroupActionService,
+    private securityGroupActionService: SecurityGroupActionService,
     private dialogService: DialogService
   ) {
+  }
+
+
+  public ngOnInit() {
+    if (this.securityGroup && this.securityGroup.preselected) {
+      this.actions = this.securityGroupActionService.actions
+        .filter(action => action.command !== SecurityGroupActionType.Delete);
+    } else {
+      this.actions = this.securityGroupActionService.actions;
+    }
   }
 
   public onAction(action): void {


### PR DESCRIPTION
Fixes #1098 
What is going on:
After the virtual machine is deleted, it is still in the list with the status removed. At this time, the security group still believes that she has a VM. After a while, CloudStack will remove the virtual machine from the list and only after this removal the security group will not have attached virtual machines and we can delete it.