### PR TITLE
fix(accounts): hide menu instead of remove to save block height

### DIFF
--- a/src/app/account/account/card-item/account-card-item.component.html
+++ b/src/app/account/account/card-item/account-card-item.component.html
@@ -13,8 +13,12 @@
     <mat-card-title [matTooltip]="item.name" class="entity-card-title">
       {{ item.name }}
     </mat-card-title>
-    <ng-container *ngIf="isAdmin() && !isSelf">
-      <button mat-icon-button [matMenuTriggerFor]="actionsMenu" class="entity-card-menu">
+    <ng-container *ngIf="isAdmin()">
+      <button
+        [style.visibility]="!isSelf ? 'visible' : 'hidden'"
+        mat-icon-button
+        [matMenuTriggerFor]="actionsMenu"
+        class="entity-card-menu">
         <mat-icon class="mdi-dots-vertical"></mat-icon>
       </button>
     </ng-container>

--- a/src/app/template/template-sidebar/template-os-icon/template-os-icon.component.html
+++ b/src/app/template/template-sidebar/template-os-icon/template-os-icon.component.html
@@ -5,25 +5,13 @@
   mat-card-avatar
 >
   <ng-template [ngSwitchCase]="'Linux'">
-    <img
-      src="img/os/linux.png"
-      width="36"
-      height="36"
-    >
+    <img src="img/os/linux.png">
   </ng-template>
   <ng-template [ngSwitchCase]="'Windows'">
-    <img
-      src="img/os/windows.png"
-      width="36"
-      height="36"
-    >
+    <img src="img/os/windows.png">
   </ng-template>
   <ng-template [ngSwitchCase]="'Mac OS'">
-    <img
-      src="img/os/osx.png"
-      width="36"
-      height="36"
-    >
+    <img src="img/os/osx.png">
   </ng-template>
   <ng-template ngSwitchDefault>
     <mat-icon class="mdi-help-circle mdi-36px"></mat-icon>

--- a/src/app/template/template-sidebar/template-os-icon/template-os-icon.component.scss
+++ b/src/app/template/template-sidebar/template-os-icon/template-os-icon.component.scss
@@ -7,3 +7,8 @@
   vertical-align: bottom;
   height: 36px !important;
 }
+
+img {
+  width: 36px;
+  height: 36px;
+}

--- a/src/app/template/template/card-item/template-card-item.component.html
+++ b/src/app/template/template/card-item/template-card-item.component.html
@@ -12,11 +12,13 @@
     <mat-card-title [matTooltip]="item.name" class="entity-card-title">
       <span [innerHTML]="item.name | highlight:query"></span>
     </mat-card-title>
-    <ng-container *ngIf="isSelf">
-      <button mat-icon-button [matMenuTriggerFor]="actionsMenu" class="entity-card-menu">
-        <mat-icon class="mdi-dots-vertical"></mat-icon>
-      </button>
-    </ng-container>
+    <button
+      [style.visibility]="isSelf ? 'visible' : 'hidden'"
+      mat-icon-button
+      [matMenuTriggerFor]="actionsMenu"
+      class="entity-card-menu">
+      <mat-icon class="mdi-dots-vertical"></mat-icon>
+    </button>
   </mat-card-header>
 
   <mat-card-content>


### PR DESCRIPTION
Fixes #1115 
Used visibility instead of ngif for account card's menu button so that the element was not removed from the DOM and passed its size.