### PR TITLE
fix(snapshots): update the way of obtaining disks with snapshots

### DIFF
--- a/src/app/reducers/snapshots/redux/snapshot.reducers.spec.ts
+++ b/src/app/reducers/snapshots/redux/snapshot.reducers.spec.ts
@@ -31,7 +31,6 @@ describe('Snapshot Reducer', () => {
     }
   ];
   const entities = { 2: snapshots[1], 1: snapshots[0] };
-  const snapshotIdsByVolumesIds = { 'volume-id': ['1'], 'volume-id-1': ['2'] };
 
   it('undefined action should return default state', () => {
     const { initialListState }: any = fromSnapshots;
@@ -57,7 +56,6 @@ describe('Snapshot Reducer', () => {
 
     expect(state.entities).toEqual(entities);
     expect(state.loading).toEqual(false);
-    expect(state.snapshotIdsByVolumeId).toEqual(snapshotIdsByVolumesIds);
     expect(state.ids).toEqual(['2', '1']);
   });
 
@@ -83,8 +81,7 @@ describe('Snapshot Reducer', () => {
       {
         ...initialListState,
         ids: ['2', '1'],
-        entities: entities,
-        snapshotIdsByVolumeId: snapshotIdsByVolumesIds
+        entities: entities
       },
       action
     );

--- a/src/app/reducers/snapshots/redux/snapshot.reducers.ts
+++ b/src/app/reducers/snapshots/redux/snapshot.reducers.ts
@@ -69,7 +69,11 @@ export function listReducer(
       };
     }
     case snapshot.LOAD_SNAPSHOT_RESPONSE: {
-      return adapter.addAll([...action.payload], state);
+      const newState = {
+        ...state,
+        loading: false
+      };
+      return adapter.addAll([...action.payload], newState);
     }
     case snapshot.SNAPSHOT_FILTER_UPDATE: {
       return { ...state, filters: { ...state.filters, ...action.payload } };

--- a/src/app/reducers/volumes/redux/volumes.reducers.ts
+++ b/src/app/reducers/volumes/redux/volumes.reducers.ts
@@ -267,13 +267,6 @@ export const selectVolumesWithSnapshots = createSelector(
   selectAll,
   fromSnapshots.selectAll,
   (volumes: Volume[], snapshots: Snapshot[]) => {
-    // return volumes.map(volume => {
-    //   const snapshotsOfVolume = snapshots.filter(snapshot => snapshot.volumeid === volume.id);
-    //   return {
-    //     ...volume,
-    //     snapshots: snapshotsOfVolume
-    //   };
-    // });
     const snapshotsByVolumeMap = snapshots.reduce((dictionary, snapshot: Snapshot) => {
       const snapshotsByVolume = dictionary[snapshot.volumeid];
       dictionary[snapshot.volumeid] = snapshotsByVolume ? [...snapshotsByVolume, snapshot] : [snapshot];

--- a/src/app/reducers/volumes/redux/volumes.reducers.ts
+++ b/src/app/reducers/volumes/redux/volumes.reducers.ts
@@ -267,12 +267,24 @@ export const selectVolumesWithSnapshots = createSelector(
   selectAll,
   fromSnapshots.selectAll,
   (volumes: Volume[], snapshots: Snapshot[]) => {
-    return volumes.map(volume => {
-      const snapshotsOfVolume = snapshots.filter(snapshot => snapshot.volumeid === volume.id);
+    // return volumes.map(volume => {
+    //   const snapshotsOfVolume = snapshots.filter(snapshot => snapshot.volumeid === volume.id);
+    //   return {
+    //     ...volume,
+    //     snapshots: snapshotsOfVolume
+    //   };
+    // });
+    const snapshotsByVolumeMap = snapshots.reduce((dictionary, snapshot: Snapshot) => {
+      const snapshotsByVolume = dictionary[snapshot.volumeid];
+      dictionary[snapshot.volumeid] = snapshotsByVolume ? [...snapshotsByVolume, snapshot] : [snapshot];
+      return dictionary;
+    }, {});
+
+    return volumes.map((volume: Volume) => {
       return {
         ...volume,
-        snapshots: snapshotsOfVolume
-      };
+        snapshots: snapshotsByVolumeMap[volume.id]
+      }
     });
   }
 );

--- a/src/app/reducers/volumes/redux/volumes.reducers.ts
+++ b/src/app/reducers/volumes/redux/volumes.reducers.ts
@@ -6,6 +6,7 @@ import * as volumeActions from './volumes.actions';
 import * as fromAccounts from '../../accounts/redux/accounts.reducers';
 import * as fromVMs from '../../vm/redux/vm.reducers';
 import * as fromSnapshots from '../../snapshots/redux/snapshot.reducers';
+import { Snapshot } from '../../../shared/models';
 import { VirtualMachine } from '../../../vm/shared/vm.model';
 
 /**
@@ -264,19 +265,15 @@ export const isFormLoading = createSelector(
 
 export const selectVolumesWithSnapshots = createSelector(
   selectAll,
-  fromSnapshots.selectEntities,
-  fromSnapshots.selectSnapshotsByVolumeId,
-  (volumes, snapshots, snapshotIdsByVolumeId) => {
-    return volumes.map(
-      volume => {
-        const snapshotsOfVolume = snapshotIdsByVolumeId[volume.id]
-          ? snapshotIdsByVolumeId[volume.id].map(snapshotId => snapshots[snapshotId])
-          : [];
-        return {
-          ...volume,
-          snapshots: snapshotsOfVolume
-        };
-      });
+  fromSnapshots.selectAll,
+  (volumes: Volume[], snapshots: Snapshot[]) => {
+    return volumes.map(volume => {
+      const snapshotsOfVolume = snapshots.filter(snapshot => snapshot.volumeid === volume.id);
+      return {
+        ...volume,
+        snapshots: snapshotsOfVolume
+      };
+    });
   }
 );
 

--- a/src/app/snapshot/snapshots-page/snapshots-page.container.ts
+++ b/src/app/snapshot/snapshots-page/snapshots-page.container.ts
@@ -10,7 +10,7 @@ import * as volumeActions from '../../reducers/volumes/redux/volumes.actions';
 import * as vmActions from '../../reducers/vm/redux/vm.actions';
 
 @Component({
-  selector: 'cs-snapshots-container',
+  selector: 'cs-snapshots-page-container',
   template: `
     <cs-snapshots-page
       [snapshots]="snapshots$ | async"


### PR DESCRIPTION
I removed a variable that was stored snapshots IDs by Volumes. Filter method was used instead to connect snapshots with their volumes.

Fixes #1101 