### PR TITLE
fix: use id and account name to check if a user belongs to the account

### DIFF
--- a/src/app/account/account/account-item.component.spec.ts
+++ b/src/app/account/account/account-item.component.spec.ts
@@ -3,7 +3,6 @@ import { AccountItemComponent } from './account-item.component';
 import { AuthService } from '../../shared/services/auth.service';
 import { User } from '../../shared/models/user.model';
 import { Account } from '../../shared/models';
-import { AccountUser } from '../../shared/models/account-user.model';
 
 class MockAuthService {
   _user: User;
@@ -33,7 +32,7 @@ describe('AccountItemComponent class only', () => {
     const account1 = 'Jonn Doe';
     const account2 = 'admin';
     const spy = spyOnProperty(authService, 'user', 'get');
-    comp.item = {user: [{account: account1} as AccountUser]} as Account;
+    comp.item = { id: '2', name: account1 } as Account;
 
     spy.and.returnValue({
       account: account1

--- a/src/app/shared/models/user.model.ts
+++ b/src/app/shared/models/user.model.ts
@@ -3,6 +3,7 @@ import { AccountType } from './account.model';
 
 export interface User extends BaseModelInterface {
   account: string;
+  accountid: string;
   domain: string;
   domainid: string;
   firstname: string;

--- a/src/app/shared/utils/account.ts
+++ b/src/app/shared/utils/account.ts
@@ -1,5 +1,9 @@
 import { Account, User } from '../models';
 
-export function isUserBelongsToAccount(user: User, account: Account) {
-  return account.user != null && user.account === account.user[0].account;
+export function isUserBelongsToAccount(user: User, account: Account): boolean {
+  /*
+   * if you check user object from login, then it does not have an accountid property
+   * thus need to check by name
+   */
+  return user.accountid === account.id || user.account === account.name;
 }


### PR DESCRIPTION
Fixes #1127 