### PR TITLE
fix(vm): do not send the root disk size parameter to the vm creation request

### DIFF
--- a/src/app/reducers/vm/redux/vm-creation.effects.ts
+++ b/src/app/reducers/vm/redux/vm-creation.effects.ts
@@ -180,10 +180,7 @@ export class VirtualMachineCreationEffects {
       }
 
       if (action.payload.template) {
-        if (action.payload.template.resourceType === TemplateResourceType.template) {
-          const rootDiskSize = Utils.convertToGb(action.payload.template.size);
-          return new vmActions.VmFormUpdate({ rootDiskSize });
-        } else if (!vmCreationState.diskOffering) {
+        if (action.payload.template.resourceType !== TemplateResourceType.template && !vmCreationState.diskOffering) {
           return new vmActions.VmFormUpdate({ diskOffering: diskOfferings[0] });
         }
       }

--- a/src/app/reducers/vm/redux/vm.reducers.ts
+++ b/src/app/reducers/vm/redux/vm.reducers.ts
@@ -350,7 +350,7 @@ export const initialFormState: FormState = {
     doStartVm: true,
     instanceGroup: null,
     keyboard: KeyboardLayout.us,
-    rootDiskSize: 0,
+    rootDiskSize: null,
     rootDiskMinSize: 0,
     securityGroupData: VmCreationSecurityGroupData.fromRules(new Rules()),
     serviceOffering: null,


### PR DESCRIPTION
Fixes #1149 
According to API:
Optional field to resize root disk on deploy. Value is in GB. Only applies to template-based deployments. Analogous to details[0].rootdisksize, which takes precedence over this parameter if both are provided

Thus I did not send this value because the application does not allow to resize the root disk for a template as an installation source.
