### PR TITLE
fix(datepicker): fix datepicker in IE11 and Edge

### DIFF
--- a/src/app/shared/components/date-picker/calendar-year.component.ts
+++ b/src/app/shared/components/date-picker/calendar-year.component.ts
@@ -50,11 +50,7 @@ export class CalendarYearComponent implements AfterViewInit {
 
     for (let year = minYear; year <= maxYear; year++) {
       dateCheck.setFullYear(year);
-      const yearFormatted = new this.DateTimeFormat(this.locale, {
-        year: 'numeric',
-      }).format(dateCheck);
-
-      years.push(yearFormatted);
+      years.push(dateCheck.getFullYear());
     }
 
     return years;


### PR DESCRIPTION
Fixes #1297 

We should consider using https://material.angular.io/components/datepicker/overview, because the current solution is a workaround for datepicker, which wasn't available for Angular Material in the past.