### PR TITLE
build(code-coverage): enable source-maps by default

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -96,6 +96,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
+            "sourceMap": true,
             "styles": [
               "node_modules/@mdi/font/css/materialdesignicons.min.css",
               "src/style/app.scss"


### PR DESCRIPTION
This is a workaround to fix code coverage mapping