### PR TITLE
Fix missing input in disk size selector

### DIFF
--- a/src/app/reducers/accounts/redux/accounts.reducers.ts
+++ b/src/app/reducers/accounts/redux/accounts.reducers.ts
@@ -244,9 +244,14 @@ export const selectStorageAvailable = createSelector(
   selectUserAccount,
   account => {
     if (account) {
-      const available = Number(account.primarystorageavailable);
+      const primaryStorage = account.primarystorageavailable;
+      if (primaryStorage === 'Unlimited') {
+        return primaryStorage;
+      }
+      const available = Number(primaryStorage);
       return !isNaN(available) ? available : null;
     }
+    return null;
   },
 );
 


### PR DESCRIPTION
Handle `Unlimited` storage case in available storage selector
closes #1651 